### PR TITLE
[DNM]Fixed strange behavior when using WithChunkReading, WithStartRow, and WithLimit together.

### DIFF
--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -45,25 +45,49 @@ class ChunkReader
         $jobs = new Collection();
         foreach ($worksheets as $name => $sheetImport) {
             $startRow = HeadingRowExtractor::determineStartRow($sheetImport);
+            $isLimit = false;
 
             if ($sheetImport instanceof WithLimit) {
                 $limit = $sheetImport->limit();
 
                 if ($limit <= $totalRows[$name]) {
-                    $totalRows[$name] = $sheetImport->limit();
+                    $totalRows[$name] = $startRow + $limit;
+                    $isLimit = true;
+
+                    if ($chunkSize > $limit) {
+                        $chunkSize = $limit;
+                    }
                 }
             }
 
-            for ($currentRow = $startRow; $currentRow <= $totalRows[$name]; $currentRow += $chunkSize) {
-                $jobs->push(new ReadChunk(
-                    $import,
-                    $reader->getPhpSpreadsheetReader(),
-                    $temporaryFile,
-                    $name,
-                    $sheetImport,
-                    $currentRow,
-                    $chunkSize
-                ));
+            if ($isLimit) {
+                for ($currentRow = $startRow; $currentRow < $totalRows[$name]; $currentRow += $chunkSize) {
+                    if (($currentRow + $chunkSize) > $totalRows[$name]) {
+                        $chunkSize -= ($currentRow + $chunkSize) - $totalRows[$name];
+                    }
+
+                    $jobs->push(new ReadChunk(
+                        $import,
+                        $reader->getPhpSpreadsheetReader(),
+                        $temporaryFile,
+                        $name,
+                        $sheetImport,
+                        $currentRow,
+                        $chunkSize
+                    ));
+                }
+            } else {
+                for ($currentRow = $startRow; $currentRow <= $totalRows[$name]; $currentRow += $chunkSize) {
+                    $jobs->push(new ReadChunk(
+                        $import,
+                        $reader->getPhpSpreadsheetReader(),
+                        $temporaryFile,
+                        $name,
+                        $sheetImport,
+                        $currentRow,
+                        $chunkSize
+                    ));
+                }
             }
         }
 

--- a/src/Imports/EndRowFinder.php
+++ b/src/Imports/EndRowFinder.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Imports;
 
+use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithLimit;
 
 class EndRowFinder
@@ -26,10 +27,18 @@ class EndRowFinder
 
         // When no start row given,
         // use the first row as start row.
-        $startRow = $startRow ?? 1;
-
         // Subtract 1 row from the start row, so a limit
         // of 1 row, will have the same start and end row.
-        return ($startRow - 1) + $limit;
+        $startRow = ($startRow ?? 1) - 1;
+
+        if ($import instanceof WithChunkReading) {
+            $chunkSize = $import->chunkSize();
+
+            $limit = ($startRow + $chunkSize) > $highestRow
+                ? $highestRow - $startRow
+                : $chunkSize;
+        }
+
+        return $startRow + $limit;
     }
 }


### PR DESCRIPTION
## 内容

Fixed strange behavior when using WithChunkReading, WithStartRow, and WithLimit together.
WithChunkReading, WithStartRow, WithLimit を併用しているときの挙動がおかしかったので修正。

File data was not loaded when limit was set to a smaller value than statRow.
statRow より limit を小さい値にするとファイルのデータが読み込まれなかった。

## 補足

とりあえず自分の Fork したリポジトリのブランチに PR だけ立てておく。

下記からは PR のデフォルト内容。

---

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣  Does it include tests, if possible?

4️⃣  Any drawbacks? Possible breaking changes?

5️⃣  Mark the following tasks as done:

- [ ] Checked the codebase to ensure that your feature doesn't already exist.
- [ ] Take note of the contributing guidelines.
- [ ] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [ ] Updated the changelog

6️⃣  Thanks for contributing! 🙌
